### PR TITLE
add error message when trying to backup VM without a policy

### DIFF
--- a/src/pages/virtual-machines/virtual-machines-list/VirtualMachinesList.tsx
+++ b/src/pages/virtual-machines/virtual-machines-list/VirtualMachinesList.tsx
@@ -71,6 +71,12 @@ const VirtualMachinesList = () => {
     {
       label: 'Backup',
       command: () => {
+        if (!actionsElement.vmBackupPolicy) {
+          alertService.error(
+            'Virtual machine is not assigned to the backup policy',
+          );
+          return;
+        }
         dispatch(
           showModalAction({
             component: BackupModal,


### PR DESCRIPTION
Error message:
> Virtual machine is not assigned to the backup policy