### PR TITLE
[SVP-9433] Fix(Backup policy): update model on load from API

### DIFF
--- a/src/pages/policies/BackupPolicy.tsx
+++ b/src/pages/policies/BackupPolicy.tsx
@@ -36,7 +36,8 @@ export const BackupPolicy = ({ type }) => {
       policiesService
         .getPolicy('vm-backup', match.params.guid)
         .then((result) => {
-          setModel({
+          setModel((_model) => ({
+            ..._model,
             ...result,
             rules: result.rules.map((rule) => ({
               ...rule,
@@ -51,7 +52,7 @@ export const BackupPolicy = ({ type }) => {
                   ) || new BackupDestinationRule('SECONDARY'),
               },
             })),
-          });
+          }));
         });
     }
 


### PR DESCRIPTION
after get data provide new data into model instead overwrite
because in `VirtualMachineBackupPolicy` model we have `executeAutoAssignmentAfterSavingPolicy` flag