### PR TITLE
[SVP-9637] Fix: Restore modals sending previous data if not changed.

### DIFF
--- a/src/components/input/reactive/Select.tsx
+++ b/src/components/input/reactive/Select.tsx
@@ -14,7 +14,6 @@ const Select = ({
    * so, for now, we will not provide this property to dropdown
    * and set "value" by first option element by default if !value
    */
-  required = false,
   ...props
 }) => {
   const [value, setValue] = useState(field.value);

--- a/src/pages/virtual-machines/virtual-machines-list/VirtualMachinesList.tsx
+++ b/src/pages/virtual-machines/virtual-machines-list/VirtualMachinesList.tsx
@@ -28,14 +28,14 @@ import { Menu } from 'primereact/menu';
 import { RestoreModal } from 'pages/virtual-machines/modal/RestoreModal';
 import HeaderTable from '../../../components/table/HeaderTable';
 import { backupsService } from '../../../services/backups-service';
-import { resetTaskAction } from '../../../store/mount-backup-modal/actions';
+import { resetMountTaskAction } from '../../../store/mount-backup-modal/actions';
 import { NoActiveRulesIcon } from 'components/modal/BackupModal/NoActiveRulesIcon';
 import { selectIsSelectedRulesZero } from 'store/backup-modal/selectors';
+import { resetRestoreTaskAction } from '../../../store/restore-modal/actions';
 
 const VirtualMachinesList = () => {
   const dispatch = useDispatch();
   const history = createBrowserHistory();
-  const [globalFilter, setGlobalFilter] = useState(null);
   const [actionsElement, setActionsElement] = useState(null);
 
   useEffect(() => {
@@ -123,7 +123,7 @@ const VirtualMachinesList = () => {
     {
       label: 'Mount',
       command: async () => {
-        dispatch(resetTaskAction());
+        dispatch(resetMountTaskAction());
         const mountableBackups = await backupsService.getMountableBackups(
           actionsElement.guid,
         );
@@ -149,6 +149,7 @@ const VirtualMachinesList = () => {
     {
       label: 'Restore',
       command: () => {
+        dispatch(resetRestoreTaskAction());
         dispatch(
           showModalAction({
             component: RestoreModal,

--- a/src/store/mount-backup-modal/actions.ts
+++ b/src/store/mount-backup-modal/actions.ts
@@ -52,7 +52,7 @@ export const setBackupFilesAction = (
   payload,
 });
 
-export const resetTaskAction = (): MountBackupModalAction => ({
+export const resetMountTaskAction = (): MountBackupModalAction => ({
   type: RESET_TASK,
 });
 

--- a/src/store/restore-modal/actions.ts
+++ b/src/store/restore-modal/actions.ts
@@ -169,6 +169,7 @@ export const submitTask = (task) => async (dispatch: Dispatch) => {
     await tasksService.submitTaskRestoreAndImportWithProjectAssign(task);
     alertService.info('Restore task has been submitted');
     await dispatch(hideModalAction());
+    await dispatch(setTaskAction(new RestoreAndImportTask()));
   } catch (e) {
     await dispatch(unsaveModalAction());
   }

--- a/src/store/restore-modal/actions.ts
+++ b/src/store/restore-modal/actions.ts
@@ -1,5 +1,6 @@
 import {
   BackupModalAction,
+  RESET_TASK,
   SET_BACKUP_FILES,
   SET_BACKUP_LOCATIONS,
   SET_FILTERED_HYPERVISOR_STORAGES,
@@ -169,7 +170,6 @@ export const submitTask = (task) => async (dispatch: Dispatch) => {
     await tasksService.submitTaskRestoreAndImportWithProjectAssign(task);
     alertService.info('Restore task has been submitted');
     await dispatch(hideModalAction());
-    await dispatch(setTaskAction(new RestoreAndImportTask()));
   } catch (e) {
     await dispatch(unsaveModalAction());
   }
@@ -191,4 +191,8 @@ export const getBackupFiles =
 export const setRestoreClusterId = (payload: any[]): BackupModalAction => ({
   type: SET_RESTORE_CLUSTER_ID,
   payload,
+});
+
+export const resetRestoreTaskAction = (): BackupModalAction => ({
+  type: RESET_TASK,
 });

--- a/src/store/restore-modal/index.ts
+++ b/src/store/restore-modal/index.ts
@@ -11,6 +11,7 @@ import {
   SET_TASK,
 } from './types';
 import { RestoreAndImportTask } from '../../model/tasks/restore-and-import-task';
+import { RESET_TASK } from '../mount-backup-modal/types';
 
 export type RestoreModalStore = {
   readonly task: any;
@@ -90,5 +91,10 @@ export default (state = initial, action: BackupModalAction) => {
       task: { ...state.task, restoreClusterId: action.payload },
     };
   }
+
+  if (action.type === RESET_TASK) {
+    return initial;
+  }
+
   return state;
 };

--- a/src/store/restore-modal/types.ts
+++ b/src/store/restore-modal/types.ts
@@ -8,6 +8,7 @@ export const SET_FILTERED_HYPERVISOR_STORAGES =
 export const SET_HYPERVISOR_CLUSTERS = 'SET_HYPERVISOR_CLUSTERS';
 export const SET_FLAVORS = 'SET_FLAVORS';
 export const SET_RESTORE_CLUSTER_ID = 'SET_RESTORE_CLUSTER_ID';
+export const RESET_TASK = 'RESET_TASK';
 
 export type SetTaskAction = {
   type: typeof SET_TASK;
@@ -54,6 +55,10 @@ export type SetRestoreClusterId = {
   payload?: any;
 };
 
+export type ResetTask = {
+  type: typeof RESET_TASK;
+};
+
 export type BackupModalAction =
   | SetTaskAction
   | SetBackupLocationsAction
@@ -63,4 +68,5 @@ export type BackupModalAction =
   | SetFilteredHypervisorStoragesAction
   | SetHypervisorClustersAction
   | SetFlavors
+  | ResetTask
   | SetRestoreClusterId;


### PR DESCRIPTION
[SVP-9637] Fix: Sending task erase Task data, Backup Location field value now overwrite previous one (if existed)